### PR TITLE
ユーザーとトーナメントの関連付け&必要情報の表示

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,6 +22,8 @@ gem 'rails-i18n'
 # 画像アップロード
 gem 'carrierwave'
 
+gem 'pry-rails'
+
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,6 +93,7 @@ GEM
       mimemagic (>= 0.3.0)
       mini_mime (>= 0.1.3)
     childprocess (3.0.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.7)
     crass (1.0.6)
     devise (4.7.2)
@@ -162,6 +163,11 @@ GEM
     orm_adapter (0.5.0)
     polyamorous (2.3.2)
       activerecord (>= 5.2.1)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.5)
     puma (4.3.5)
       nio4r (~> 2.0)
@@ -282,6 +288,7 @@ DEPENDENCIES
   devise
   jbuilder (~> 2.7)
   listen (~> 3.2)
+  pry-rails
   puma (~> 4.1)
   rails (~> 6.0.3, >= 6.0.3.2)
   rails-i18n

--- a/app/controllers/tournaments_controller.rb
+++ b/app/controllers/tournaments_controller.rb
@@ -13,17 +13,16 @@ class TournamentsController < ApplicationController
   def confirm
     @tournament = Tournament.new(tournament_params)
     return if @tournament.valid?
-    render :new
   end
 
   def back
     @tournament = Tournament.new(tournament_params)
-
     render :new
   end
 
   def create
     @tournament = Tournament.new(tournament_params)
+    @tournament.user_id = current_user.id
     if @tournament.save
       redirect_to tournaments_path notice: 'イベントを投稿しました。' 
     else
@@ -33,6 +32,7 @@ class TournamentsController < ApplicationController
 
   def show
     @tournament = Tournament.find(params[:id])
+    @user = @tournament.user
   end
 
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,6 +5,7 @@ class UsersController < ApplicationController
 
   def my_show
     @user = User.find(current_user.id)
+    @tournaments = @user.tournaments
   end
 
   def show

--- a/app/models/tournament.rb
+++ b/app/models/tournament.rb
@@ -10,6 +10,8 @@ class Tournament < ApplicationRecord
   validates_acceptance_of :confirming
   after_validation :check_confirming
 
+  belongs_to :user
+
   def check_confirming
     errors.delete(:confirming)
     self.confirming = errors.empty? ? '1' : ''

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,4 +6,6 @@ class User < ApplicationRecord
 
   validates :nickname, presence: true
   mount_uploader :image, ImageUploader
+
+  has_many :tournaments
 end

--- a/app/views/tournaments/show.html.erb
+++ b/app/views/tournaments/show.html.erb
@@ -8,6 +8,9 @@
     <p><%= "最大匹数：#{@tournament.some_fish}" %></p>
     <p><%= "詳細内容：#{@tournament.comment}" %></p>
 
+    <%= image_tag @user.image.url %>
+    <h1><%= @user.nickname %></h1>
+
   <%# <% if user_signed_in? && current_user.id == @tournament[:id] %> %>
     <div class="btn_group">
       <%= link_to '編集', edit_tournament_path(@tournament), class:"btn"  %>

--- a/app/views/users/my_show.html.erb
+++ b/app/views/users/my_show.html.erb
@@ -7,6 +7,13 @@
     <%= link_to 'プロフィール編集', edit_user_path(current_user), class:"btn"  %>
   </div>
 
+
+  <%# <% @tournaments.each do |tournament| %> %>
+    <%# <hr> %>
+    <%# <p><span>投稿したトーナメント内容: </span><%=link_to tournaments.fishing_ground, tournament_path(tournament.id) %></p> %>
+  <%# <% end %> %>
+
+
   <div class="profile">
     <%= image_tag @user.image.url %>
     <div class="nickname">
@@ -28,5 +35,10 @@
       <label>コメント：</label> <%= @user.comment %>
     </div>
   </div>
+
+
+ <% @tournaments.each do |tournament| %>
+  <p><span>投稿内容: </span><%= tournament.fishing_ground %></p>
+ <% end %>
 
 </div>

--- a/db/migrate/20200906121237_add_column_tournaments.rb
+++ b/db/migrate/20200906121237_add_column_tournaments.rb
@@ -1,0 +1,5 @@
+class AddColumnTournaments < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tournaments, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_09_04_065213) do
+ActiveRecord::Schema.define(version: 2020_09_06_121237) do
 
   create_table "active_admin_comments", force: :cascade do |t|
     t.string "namespace"
@@ -57,6 +57,7 @@ ActiveRecord::Schema.define(version: 2020_09_04_065213) do
     t.text "comment"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.integer "user_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
【実装内容】
ユーザーとトーナメントの関連付けを行なって、トーナメントの作成者を表示させる
ユーザーイメージと名前を表示